### PR TITLE
supporting one-way binding with the equal converter

### DIFF
--- a/can-stache-converters.js
+++ b/can-stache-converters.js
@@ -70,11 +70,8 @@ stache.registerConverter("either-or", {
 
 stache.registerConverter("equal", {
 	get: function(compute, comparer){
-		if(!compute || !compute.isComputed) {
-			throw new Error("'equal' must be given a can-compute as the first argument");
-		}
-
-		return compute() === comparer;
+		var val = (compute && compute.isComputed) ? compute() : compute;
+		return val === comparer;
 	},
 	set: function(b, compute, comparer){
 		if(b) {

--- a/docs/equal.md
+++ b/docs/equal.md
@@ -20,11 +20,26 @@ In this example, the `color` scope value will be set to 'red' when the first rad
 
 @return {can-compute} A compute that will be two-way bound to the radio's checked property.
 
+@signature `equal(valueOne, valueTwo)`
+
+When the getter is called the two values will be compared and if they are equal, returns true.
+
+```handlebars
+<my-modal {show}="equal(showModal, true)" />
+```
+
+In this example, the `show` value of `my-modal`'s view model will be set to `true` when `showModal` in the scope is set to true.
+
+@param {*} valueOne A value of any type, that will be compared to valueTwo.
+@param {*} valueTwo A value of any type, that will be compared to valueOne.
+
+@return {can-compute} A compute that will be one-way bound to the `show` property.
+
 @body 
 
 ## Use
 
-This [can-stache.converter converter] will most often be used in conjunction with a radio input in order to bind a scope's value (such as string, but could be any value) based on the selection of the radio group.
+This [can-stache-converters converter] will most often be used in conjunction with a radio input in order to bind a scope's value (such as string, but could be any value) based on the selection of the radio group.
 
 In this example we are using objects, to select a captain from one of three players:
 

--- a/test/equal_test.js
+++ b/test/equal_test.js
@@ -34,14 +34,19 @@ QUnit.test("Basics works", function(){
 	QUnit.equal(no.checked, false, "no is unchecked");
 });
 
-QUnit.test("Throws when not passed a compute as the first argument", function(){
-	var template = stache('<input type="radio" {($checked)}="equal(attending, \'yes\'" />');
-	var attending = compute("yes");
+QUnit.test("Allows one-way binding when passed a non-compute as the first argument", function(){
+	var template = stache('<input type="radio" {($checked)}="equal(attending, true)" />');
+	var attending = compute(false);
 
-	try {
-		template(attending);
-	} catch(err) {
-		var msg = err.message;
-		QUnit.ok(/can-compute/.test(msg), "got an error about a can-compute being needed");
-	}
+	var input = template({ attending: attending }).firstChild;
+
+	QUnit.equal(input.checked, false, 'initially false');
+
+	attending(true);
+
+	QUnit.equal(input.checked, true, 'can be changed to true');
+
+	input.checked = false;
+
+	QUnit.equal(attending(), true, 'does not change compute');
 });


### PR DESCRIPTION
Closes https://github.com/canjs/can-stache-converters/issues/6.