### PR TITLE
#32 - Update `either-or`

### DIFF
--- a/can-stache-converters.js
+++ b/can-stache-converters.js
@@ -1,6 +1,7 @@
 var stache = require("can-stache");
 var stringToAny = require("can-util/js/string-to-any/string-to-any");
 var makeArray = require("can-util/js/make-array/make-array");
+var dev = require("can-util/js/dev/dev");
 require("can-stache-bindings");
 
 stache.registerConverter("boolean-to-inList", {
@@ -62,7 +63,24 @@ stache.registerConverter("index-to-selected", {
 
 stache.registerConverter("either-or", {
 	get: function(chosen, a, b){
-		return b !== chosen();
+		var matchA = (a === chosen());
+		var matchB = (b === chosen());
+
+		if (!matchA && !matchB) {
+			//!steal-remove-start
+			dev.warn(
+				"can-stache-converter.either-or:",
+				"`" + chosen() + "`",
+				"does not match `" + a + "`",
+				"or `" + b + "`"
+			);
+			//!steal-remove-end
+
+			return;
+		}
+		else {
+			return matchA;
+		}
 	},
 	set: function(newVal, chosen, a, b){
 		chosen(newVal ? a : b);

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ When the setter is called, if the new value is truthy then the item will be adde
 ```
 
 
-1. __item__ <code>{*}</code>:
+1. __item__ <code>{\*}</code>:
   The item to which to check
 1. __list__ <code>{can-define/list/list|can-list|Array}</code>:
   The list
@@ -111,23 +111,32 @@ When the setter is called, takes the selected index value and finds the item fro
 ### <code>either-or(~chosen, a, b)</code>
 
 
-When the getter is called, gets the value of the **chosen** compute and if it is equal to **a** returns true, otherwise it returns false.
-
-When the setter is called, if the new value is truthy, sets the **chosen** [can-compute] to **a**'s value, otherwise sets it to **b**'s value.
+Map values to boolean attributes.
 
 ```handlebars
-<span>Favorite superhero:</span>
-<input type="checkbox" {($checked)}="either-or(~chosen, 'Batman', 'Superman')"> Batman?
+<span>Want some?</span>
+<label>
+  <input type="checkbox" {($checked)}="either-or(~wantSome, 'Yes', 'No')"> Yes
+</label>
 ```
 
+| property | initial _~chosen_ value | _a_: truthy case  | _b_: falsey  case | either-or return | final ~chosen value
+| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
+| wantSome | Yes | Yes | No | true | Yes |
+| wantSome | No | Yes | No | false | No |
+| wantSome | __Maybe__ | Yes | No | undefined\* | __No__ |
+| wantSome | __undefined__ | Yes | No | undefined\* | __No__ |
+| wantSome | __null__ | Yes | No | undefined\* | __No__ |
+
+_\* A dev warning is logged if neither a or b match ~chosen._
 
 1. __chosen__ <code>{can-compute}</code>:
   A compute where the chosen value (between `a` and `b` is stored). When the setter is called, this compute's value will be updated.
   
-1. __a__ <code>{*}</code>:
+1. __a__ <code>{\*}</code>:
   The `true` value. If the checkbox is checked, then **a**'s value will be stored in the **chosen** compute.
   
-1. __b__ <code>{*}</code>:
+1. __b__ <code>{\*}</code>:
   The `false` value. If the checkbox is unchecked, then **b**'s value will be stored in the **chosen** compute.
   
 

--- a/test/either-or_test.js
+++ b/test/either-or_test.js
@@ -1,5 +1,6 @@
 require("can-stache-converters");
 var canEvent = require("can-event");
+var compute = require("can-compute");
 var DefineMap = require("can-define/map/map");
 var stache = require("can-stache");
 var QUnit = require("steal-qunit");
@@ -7,12 +8,12 @@ var QUnit = require("steal-qunit");
 QUnit.module("either-or");
 
 QUnit.test("can bind to a checkbox", function(){
-	var template = stache("<input type='checkbox' {($checked)}='either-or(~pref, \"Star Trek\", \"Star Wars\")' />");
+	var renderer = stache("<input type='checkbox' {($checked)}='either-or(~pref, \"Star Trek\", \"Star Wars\")' />");
 	var map = new DefineMap({
 		pref: "Star Trek"
 	});
 
-	var input = template(map).firstChild;
+	var input = renderer(map).firstChild;
 
 	QUnit.equal(input.checked, true, "initial value is right");
 
@@ -25,3 +26,68 @@ QUnit.test("can bind to a checkbox", function(){
 	QUnit.equal(input.checked, true, "changed because map changed");
 });
 
+QUnit.test("initial null selection", function() {
+	var renderer = stache("<input type='checkbox' {($checked)}='either-or(~pref, \"Yes\", \"No\")' />");
+	var map = new DefineMap({
+		pref: null
+	});
+	var input = renderer(map).firstChild;
+
+	QUnit.equal(input.checked, false, "checkbox is unchecked");
+	QUnit.strictEqual(map.pref, "No", "null value changed to falsey case by checkbox");
+
+	input.checked = true;
+	canEvent.trigger.call(input, "change");
+	QUnit.equal(map.pref, "Yes", "map updated because check was checked");
+});
+
+QUnit.test("initial undefined selection", function() {
+	var renderer = stache("<input type='checkbox' {($checked)}='either-or(~pref, \"Yes\", \"No\")' />");
+	var map = new DefineMap({
+		pref: undefined
+	});
+	var input = renderer(map).firstChild;
+
+	QUnit.equal(input.checked, false, "checkbox is unchecked");
+	QUnit.strictEqual(map.pref, "No", "undefined value changed to falsey case by checkbox");
+
+	input.checked = true;
+	canEvent.trigger.call(input, "change");
+	QUnit.equal(map.pref, "Yes", "map updated because check was checked");
+});
+
+QUnit.test("initial no match selection", function() {
+	var renderer = stache("<input type='checkbox' {($checked)}='either-or(~pref, \"Yes\", \"No\")' />");
+	var map = new DefineMap({
+		pref: "fubar"
+	});
+	var input = renderer(map).firstChild;
+
+	QUnit.equal(input.checked, false, "checkbox is unchecked");
+	QUnit.strictEqual(map.pref, "No", "fubar value changed to falsey case by checkbox");
+
+	input.checked = true;
+	canEvent.trigger.call(input, "change");
+	QUnit.equal(map.pref, "Yes", "map updated because check was checked");
+});
+
+QUnit.test("supports computes", function() {
+	var renderer = stache("<input type='checkbox' {($checked)}='either-or(~pref, a, b)' />");
+	var map = new DefineMap({
+		pref: compute("Maybe"),
+		a: compute("Yes"),
+		b: compute("No")
+	});
+	var input = renderer(map).firstChild;
+
+	QUnit.equal(input.checked, false, "checkbox is unchecked");
+	QUnit.strictEqual(map.pref(), "No", "chosen value changed to falsey case by checkbox");
+
+	input.checked = true;
+	canEvent.trigger.call(input, "change");
+	QUnit.equal(map.pref(), "Yes", "map updated because check was checked");
+
+	input.checked = false;
+	canEvent.trigger.call(input, "change");
+	QUnit.equal(map.pref(), "No", "map updated because check was unchecked");
+});


### PR DESCRIPTION
- return `undefined` and dev.warn in console if neither `a` or `b` match `~chosen`
- add tests including compute use
- update documentation

Resolves #32 