### PR TITLE
add selected-to-index

### DIFF
--- a/can-stache-converters.js
+++ b/can-stache-converters.js
@@ -12,7 +12,6 @@ stache.registerConverter("boolean-to-inList", {
 			return list.indexOf(item) !== -1;
 		}
 	},
-
 	set: function(newVal, item, list){
 		if(!list) {
 			return;
@@ -55,8 +54,22 @@ stache.registerConverter("index-to-selected", {
 	},
 	set: function(idx, item, list){
 		var newVal = list[idx];
-		if(newVal !== -1 && item.isComputed) {
+		if(item.isComputed) {
 			item(newVal);
+		}
+	}
+});
+
+stache.registerConverter("selected-to-index", {
+	get: function(idx, list){
+		var val = idx.isComputed ? idx() : idx;
+		var item = list[val];
+		return item;
+	},
+	set: function(item, idx, list){
+		var newVal = list.indexOf(item);
+		if(idx.isComputed) {
+			idx(newVal);
 		}
 	}
 });

--- a/docs/selected-to-index.md
+++ b/docs/selected-to-index.md
@@ -1,0 +1,25 @@
+@function can-stache-converters.selected-to-index selected-to-index
+@parent can-stache-converters.converters
+@description A [can-stache.registerConverter converter] that binds an index in a list to the selected item's value as a viewModel property.
+
+@signature `selected-to-index(~index, list)`
+
+When the getter is called, returns the item at the passed in index (which should be a [can-compute] from the provided list.
+
+When the setter is called, takes the selected item and finds the index from the list and passes that to set the compute’s value.
+
+```handlebars
+<input value:bind="selected-to-index(~index, people)" />
+```
+
+@param {can-compute} item A compute whose value is an index from the list.
+@param {can-define/list/list|can-list|Array} list A list used to find the `item`.
+@return {can-compute} A compute that will be two-way bound to the value.
+
+@body
+
+## Use
+
+The provided `index` **must** be a [can-compute] so that its value can be set on user actions.
+
+@demo demos/can-stache-converters/selected-to-index.html

--- a/test/selected-to-index_test.js
+++ b/test/selected-to-index_test.js
@@ -1,0 +1,45 @@
+require("can-stache-converters");
+var canEvent = require("can-event");
+var DefineList = require("can-define/list/list");
+var DefineMap = require("can-define/map/map");
+var stache = require("can-stache");
+var each = require("can-util/js/each/each");
+
+var QUnit = require("steal-qunit");
+
+QUnit.module("selected-to-index");
+
+QUnit.test("sets index by the value from a list", function(){
+	var template = stache('<input value:bind="selected-to-index(~index, people)" />');
+
+	var map = new DefineMap({
+		index: "1",
+		people: [
+			"Matthew",
+			"Anne",
+			"Wilbur"
+		]
+	});
+
+	var input = template(map).firstChild;
+
+	// Initial value
+	QUnit.equal(input.value, "Anne", "initially set to the first value");
+
+	// Select a different thing.
+	input.value = "Wilbur";
+	canEvent.trigger.call(input, "change");
+
+	QUnit.equal(map.index, "2", "now it is me");
+
+	// Change the selected the other way.
+	map.index = "0";
+
+	QUnit.equal(input.value, "Matthew", "set back");
+
+	// Can be set to other stuff too
+	input.value = "none";
+	canEvent.trigger.call(input, "change");
+
+	QUnit.equal(map.index, -1, "now -1 because not in the list");
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,6 @@
 require("./boolean-to-inList_test");
 require("./index-to-selected_test");
+require("./selected-to-index_test");
 require("./string-to-any_test");
 require("./not_test");
 require("./either-or_test");


### PR DESCRIPTION
Fixes #28 . I tried to create a generic way to reverse a converter but had no success. Upon further digging, this seems to be the only converter that makes sense to reverse (perhaps also `string-to-any`, but the rules would be very complicated).

This also fixes an [unreported bug](https://github.com/canjs/can-stache-converters/blob/5ead039734f987b545fc6e5098ffcde9b82de042/can-stache-converters.js#L58) that I found while digging. If the list had an item of `-1`, it would not update properly.