### PR TITLE
Update input[type=radio] docs to show new syntax

### DIFF
--- a/docs/can-stache-converters.md
+++ b/docs/can-stache-converters.md
@@ -54,5 +54,4 @@ For multiple-selection lists, `values:bind="key"` cross-binds selected options w
 The value of the observable is changed after the textarea's `change` event,
 which is after `blur`.
 
-> There is a way of making changes respond to key events as well: `on:keyup="%scope.set('key', %element.value)`.  However, this  sets the value of `key` at the current scope level.  If `key` was set at a higher level of the scope, the cross binding of `value:bind` will not point to the same item as the keyup target.
-
+> There is a way of making changes respond to key events as well: `on:keyup="scope.set('key', scope.element.value)`.  However, this  sets the value of `key` at the current scope level.  If `key` was set at a higher level of the scope, the cross binding of `value:bind` will not point to the same item as the keyup target.

--- a/docs/index-to-selected.md
+++ b/docs/index-to-selected.md
@@ -13,7 +13,7 @@ When the setter is called, takes the selected index value and finds the item fro
 
 	{{#each people}}
 
-		<option value="{{%index}}">{{name}}</option>
+		<option value="{{scope.index}}">{{name}}</option>
 
 	{{/each}}
 

--- a/docs/input-radio.md
+++ b/docs/input-radio.md
@@ -10,8 +10,8 @@ Cross bind a value to a radio input.
 To bind to a radio input, if you have a set of boolean values you can bind to the input’s `checked` property as you do with [can-stache-converters.examples.input-checkbox].
 
 ```handlebars
-<input type="radio" {($checked)}="one" /> One
-<input type="radio" {($checked)}="two" /> Two
+<input type="radio" checked:bind="one" /> One
+<input type="radio" checked:bind="two" /> Two
 ```
 
 ```js


### PR DESCRIPTION
Also update legacy `%` syntax.