### PR TITLE
Upgrade to can 4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ node_modules
 
 doc/
 dist/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -38,20 +38,21 @@
     "main": "can-stache-converters"
   },
   "dependencies": {
-    "can-stache": "^3.1.0",
-    "can-stache-bindings": "^3.2.0",
-    "can-util": "^3.9.0"
+    "can-reflect": "^1.11.1",
+    "can-stache": "^4.0.0-pre.0",
+    "can-stache-bindings": "^4.0.0-pre.0",
+    "can-util": "^3.10.18"
   },
   "devDependencies": {
     "bit-docs": "0.0.7",
-    "can-compute": "^3.1.0",
-    "can-define": "^1.2.0",
+    "can-compute": "^4.0.0-pre.9",
+    "can-define": "^2.0.0-pre.24",
     "can-event": "^3.5.0",
     "detect-cyclic-packages": "^1.1.0",
     "documentjs": "^0.4.2",
-    "done-serve": "^1.2.0",
-    "donejs-cli": "^1.0.1",
-    "generator-donejs": "^1.0.5",
+    "done-serve": "^2.0.0-pre.0",
+    "donejs-cli": "^2.0.0-pre.0",
+    "generator-donejs": "^2.0.0-pre.2",
     "jshint": "^2.9.1",
     "steal": "^1.2.10",
     "steal-qunit": "^1.0.1",

--- a/test/boolean-to-inList_test.js
+++ b/test/boolean-to-inList_test.js
@@ -1,9 +1,9 @@
 require("can-stache-converters");
-var canEvent = require("can-event");
 var DefineList = require("can-define/list/list");
 var DefineMap = require("can-define/map/map");
 var stache = require("can-stache");
 var each = require("can-util/js/each/each");
+var domEvents = require("can-util/dom/events/events");
 
 var QUnit = require("steal-qunit");
 
@@ -14,7 +14,7 @@ QUnit.module("boolean-to-inList", {
 });
 
 QUnit.test("Works with checkboxes", function(){
-	var template = stache("<input type='checkbox' {($checked)}='boolean-to-inList(item, list)' />");
+	var template = stache("<input type='checkbox' checked:bind='boolean-to-inList(item, list)' />");
 	var map = new DefineMap({
 		item: 2,
 		list: new DefineList([ 1, 2, 3 ])
@@ -27,7 +27,7 @@ QUnit.test("Works with checkboxes", function(){
 	QUnit.equal(map.list.indexOf(2), 1, "two is in the list");
 
 	input.checked = false;
-	canEvent.trigger.call(input, "change");
+	domEvents.dispatch.call(input, "change");
 
 	QUnit.equal(map.list.indexOf(2), -1, "No longer in the list");
 
@@ -43,13 +43,13 @@ QUnit.test("Works with checkboxes", function(){
 
 	map.item = 6;
 	input.checked = true;
-	canEvent.trigger.call(input, "change");
+	domEvents.dispatch.call(input, "change");
 
 	QUnit.equal(map.list.indexOf(6), 3, "pushed into the list");
 });
 
 QUnit.test("If there is no list, treated as false", function(){
-	var template = stache("<input type='checkbox' {($checked)}='boolean-to-inList(item, list)' />");
+	var template = stache("<input type='checkbox' checked:bind='boolean-to-inList(item, list)' />");
 	var map = new DefineMap({
 		item: 2,
 		list: undefined
@@ -60,13 +60,13 @@ QUnit.test("If there is no list, treated as false", function(){
 	QUnit.ok(!input.checked, "not checked because there is no list");
 
 	input.checked = true;
-	canEvent.trigger.call(input, "change");
+	domEvents.dispatch.call(input, "change");
 
 	QUnit.ok(true, "no errors thrown");
 });
 
 QUnit.test("works with radio buttons", function(){
-	var template = stache("<form><input type='radio' name='name' value='Matthew' {($checked)}='boolean-to-inList(\"Matthew\", names)' /><input type='radio' name='name' value='Wilbur' {($checked)}='boolean-to-inList(\"Wilbur\", names)' /></form>");
+	var template = stache("<form><input type='radio' name='name' value='Matthew' checked:bind='boolean-to-inList(\"Matthew\", names)' /><input type='radio' name='name' value='Wilbur' checked:bind='boolean-to-inList(\"Wilbur\", names)' /></form>");
 	var map = new DefineMap({
 		names: ['Wilbur']
 	});
@@ -82,7 +82,7 @@ QUnit.test("works with radio buttons", function(){
 	QUnit.equal(radioTwo.checked, true, "Wilbur is checked");
 
 	radioOne.checked = true;
-	canEvent.trigger.call(radioOne, "change");
+	domEvents.dispatch.call(radioOne, "change");
 
 	QUnit.equal(radioOne.checked, true, "Matthew is checked");
 	QUnit.equal(radioTwo.checked, false, "Wilbur is not checked");

--- a/test/either-or_test.js
+++ b/test/either-or_test.js
@@ -1,14 +1,14 @@
 require("can-stache-converters");
-var canEvent = require("can-event");
 var compute = require("can-compute");
 var DefineMap = require("can-define/map/map");
+var domEvents = require("can-util/dom/events/events");
 var stache = require("can-stache");
 var QUnit = require("steal-qunit");
 
 QUnit.module("either-or");
 
 QUnit.test("can bind to a checkbox", function(){
-	var renderer = stache("<input type='checkbox' {($checked)}='either-or(~pref, \"Star Trek\", \"Star Wars\")' />");
+	var renderer = stache("<input type='checkbox' checked:bind='either-or(~pref, \"Star Trek\", \"Star Wars\")' />");
 	var map = new DefineMap({
 		pref: "Star Trek"
 	});
@@ -18,7 +18,7 @@ QUnit.test("can bind to a checkbox", function(){
 	QUnit.equal(input.checked, true, "initial value is right");
 
 	input.checked = false;
-	canEvent.trigger.call(input, "change");
+	domEvents.dispatch.call(input, "change");
 
 	QUnit.equal(map.pref, "Star Wars", "changed because input changed");
 
@@ -27,7 +27,7 @@ QUnit.test("can bind to a checkbox", function(){
 });
 
 QUnit.test("initial null selection", function() {
-	var renderer = stache("<input type='checkbox' {($checked)}='either-or(~pref, \"Yes\", \"No\")' />");
+	var renderer = stache("<input type='checkbox' checked:bind='either-or(~pref, \"Yes\", \"No\")' />");
 	var map = new DefineMap({
 		pref: null
 	});
@@ -37,12 +37,12 @@ QUnit.test("initial null selection", function() {
 	QUnit.strictEqual(map.pref, "No", "null value changed to falsey case by checkbox");
 
 	input.checked = true;
-	canEvent.trigger.call(input, "change");
+	domEvents.dispatch.call(input, "change");
 	QUnit.equal(map.pref, "Yes", "map updated because check was checked");
 });
 
 QUnit.test("initial undefined selection", function() {
-	var renderer = stache("<input type='checkbox' {($checked)}='either-or(~pref, \"Yes\", \"No\")' />");
+	var renderer = stache("<input type='checkbox' checked:bind='either-or(~pref, \"Yes\", \"No\")' />");
 	var map = new DefineMap({
 		pref: undefined
 	});
@@ -52,12 +52,12 @@ QUnit.test("initial undefined selection", function() {
 	QUnit.strictEqual(map.pref, "No", "undefined value changed to falsey case by checkbox");
 
 	input.checked = true;
-	canEvent.trigger.call(input, "change");
+	domEvents.dispatch.call(input, "change");
 	QUnit.equal(map.pref, "Yes", "map updated because check was checked");
 });
 
 QUnit.test("initial no match selection", function() {
-	var renderer = stache("<input type='checkbox' {($checked)}='either-or(~pref, \"Yes\", \"No\")' />");
+	var renderer = stache("<input type='checkbox' checked:bind='either-or(~pref, \"Yes\", \"No\")' />");
 	var map = new DefineMap({
 		pref: "fubar"
 	});
@@ -67,12 +67,12 @@ QUnit.test("initial no match selection", function() {
 	QUnit.strictEqual(map.pref, "No", "fubar value changed to falsey case by checkbox");
 
 	input.checked = true;
-	canEvent.trigger.call(input, "change");
+	domEvents.dispatch.call(input, "change");
 	QUnit.equal(map.pref, "Yes", "map updated because check was checked");
 });
 
 QUnit.test("supports computes", function() {
-	var renderer = stache("<input type='checkbox' {($checked)}='either-or(~pref, a, b)' />");
+	var renderer = stache("<input type='checkbox' checked:bind='either-or(~pref, a, b)' />");
 	var map = new DefineMap({
 		pref: compute("Maybe"),
 		a: compute("Yes"),
@@ -84,10 +84,10 @@ QUnit.test("supports computes", function() {
 	QUnit.strictEqual(map.pref(), "No", "chosen value changed to falsey case by checkbox");
 
 	input.checked = true;
-	canEvent.trigger.call(input, "change");
+	domEvents.dispatch.call(input, "change");
 	QUnit.equal(map.pref(), "Yes", "map updated because check was checked");
 
 	input.checked = false;
-	canEvent.trigger.call(input, "change");
+	domEvents.dispatch.call(input, "change");
 	QUnit.equal(map.pref(), "No", "map updated because check was unchecked");
 });

--- a/test/equal_test.js
+++ b/test/equal_test.js
@@ -1,8 +1,8 @@
 require("can-stache-converters");
-var canEvent = require("can-event");
 var compute = require("can-compute");
 var DefineList = require("can-define/list/list");
 var DefineMap = require("can-define/map/map");
+var domEvents = require("can-util/dom/events/events");
 var stache = require("can-stache");
 var each = require("can-util/js/each/each");
 
@@ -11,7 +11,7 @@ var QUnit = require("steal-qunit");
 QUnit.module("equal");
 
 QUnit.test("Basics works", function(){
-	var template = stache('<input type="radio" {($checked)}="equal(~attending, \'yes\'" /><input type="radio" {($checked)}="equal(~attending, \'no\'" />');
+	var template = stache('<input type="radio" checked:bind="equal(~attending, \'yes\'" /><input type="radio" checked:bind="equal(~attending, \'no\'" />');
 	var attending = compute("yes");
 
 	var yes = template({ attending: attending }).firstChild,
@@ -27,7 +27,7 @@ QUnit.test("Basics works", function(){
 
 	// User changing stuff
 	yes.checked = true;
-	canEvent.trigger.call(yes, "change");
+	domEvents.dispatch.call(yes, "change");
 
 	QUnit.equal(attending(), "yes", "now it is yes");
 	QUnit.equal(yes.checked, true, "yes is checked");
@@ -35,7 +35,7 @@ QUnit.test("Basics works", function(){
 });
 
 QUnit.test("Allows one-way binding when passed a non-compute as the first argument", function(){
-	var template = stache('<input type="radio" {($checked)}="equal(attending, true)" />');
+	var template = stache('<input type="radio" checked:bind="equal(attending, true)" />');
 	var attending = compute(false);
 
 	var input = template({ attending: attending }).firstChild;
@@ -52,7 +52,7 @@ QUnit.test("Allows one-way binding when passed a non-compute as the first argume
 });
 
 QUnit.test("Allow multiple expressions to be passed in", function() {
-	var template = stache('<input type="radio" {($checked)}="equal(~foo, ~bar, true)" />');
+	var template = stache('<input type="radio" checked:bind="equal(~foo, ~bar, true)" />');
 	var foo = compute(true);
 	var bar = compute(false);
 
@@ -73,7 +73,7 @@ QUnit.test("Allow multiple expressions to be passed in", function() {
 	QUnit.equal(input.checked, false, 'now unchecked');
 
 	input.checked = true;
-	canEvent.trigger.call(input, "change");
+	domEvents.dispatch.call(input, "change");
 
 	QUnit.equal(foo(), true, 'computed foo value is true');
 	QUnit.equal(bar(), true, 'computed bar value is true');

--- a/test/index-to-selected_test.js
+++ b/test/index-to-selected_test.js
@@ -1,7 +1,7 @@
 require("can-stache-converters");
-var canEvent = require("can-event");
 var DefineList = require("can-define/list/list");
 var DefineMap = require("can-define/map/map");
+var domEvents = require("can-util/dom/events/events");
 var stache = require("can-stache");
 var each = require("can-util/js/each/each");
 
@@ -10,7 +10,7 @@ var QUnit = require("steal-qunit");
 QUnit.module("index-to-selected");
 
 QUnit.test("chooses select option by the index from a list", function(){
-	var template = stache('<select {($value)}="index-to-selected(~person, people)"><option value="none"></option>{{#each people}}<option value="{{%index}}">{{name}}</option>{{/each}}</select>');
+	var template = stache('<select value:bind="index-to-selected(~person, people)"><option value="none"></option>{{#each people}}<option value="{{scope.index}}">{{name}}</option>{{/each}}</select>');
 
 	var map = new DefineMap({
 		person: "Anne",
@@ -28,7 +28,7 @@ QUnit.test("chooses select option by the index from a list", function(){
 
 	// Select a different thing.
 	select.value = 2;
-	canEvent.trigger.call(select, "change");
+	domEvents.dispatch.call(select, "change");
 
 	QUnit.equal(map.person, "Wilbur", "now it is me");
 
@@ -39,7 +39,7 @@ QUnit.test("chooses select option by the index from a list", function(){
 
 	// Can be set to other stuff too
 	select.value = "none";
-	canEvent.trigger.call(select, "change");
+	domEvents.dispatch.call(select, "change");
 
 	QUnit.equal(map.person, undefined, "now undefined because not in the list");
 });

--- a/test/not_test.js
+++ b/test/not_test.js
@@ -1,7 +1,7 @@
 require("can-stache-converters");
-var canEvent = require("can-event");
 var DefineList = require("can-define/list/list");
 var DefineMap = require("can-define/map/map");
+var domEvents = require("can-util/dom/events/events");
 var stache = require("can-stache");
 var each = require("can-util/js/each/each");
 
@@ -10,7 +10,7 @@ var QUnit = require("steal-qunit");
 QUnit.module("not");
 
 QUnit.test("saves the inverse of the selected value", function(){
-	var template = stache('<input type="checkbox" {($checked)}="not(~val)" />');
+	var template = stache('<input type="checkbox" checked:bind="not(~val)" />');
 	var map = new DefineMap({
 		val: true
 	});
@@ -24,13 +24,13 @@ QUnit.test("saves the inverse of the selected value", function(){
 	QUnit.equal(input.checked, true, "true because map val is false");
 
 	input.checked = false;
-	canEvent.trigger.call(input, "change");
+	domEvents.dispatch.call(input, "change");
 
 	QUnit.equal(map.val, true, "map is now true because checkbox is false");
 });
 
 QUnit.test("works with boolean-to-inList", function(){
-	var template = stache("<input type='checkbox' {($checked)}='not(~boolean-to-inList(item, list))' />");
+	var template = stache("<input type='checkbox' checked:bind='not(~boolean-to-inList(item, list))' />");
 	var map = new DefineMap({
 		item: 2,
 		list: new DefineList([ 1, 2, 3 ])
@@ -45,7 +45,7 @@ QUnit.test("works with boolean-to-inList", function(){
 	QUnit.equal(input.checked, true, "checked because not in the list");
 
 	input.checked = false;
-	canEvent.trigger.call(input, "change");
+	domEvents.dispatch.call(input, "change");
 
 	QUnit.equal(map.list.indexOf(4), 3, "it was pushed into the list");
 
@@ -53,4 +53,3 @@ QUnit.test("works with boolean-to-inList", function(){
 	map.list.splice(3, 1);
 	QUnit.equal(input.checked, true, "now it's checked because not in the list");
 });
-

--- a/test/selected-to-index_test.js
+++ b/test/selected-to-index_test.js
@@ -1,7 +1,7 @@
 require("can-stache-converters");
-var canEvent = require("can-event");
 var DefineList = require("can-define/list/list");
 var DefineMap = require("can-define/map/map");
+var domEvents = require("can-util/dom/events/events");
 var stache = require("can-stache");
 var each = require("can-util/js/each/each");
 
@@ -28,7 +28,7 @@ QUnit.test("sets index by the value from a list", function(){
 
 	// Select a different thing.
 	input.value = "Wilbur";
-	canEvent.trigger.call(input, "change");
+	domEvents.dispatch.call(input, "change");
 
 	QUnit.equal(map.index, "2", "now it is me");
 
@@ -39,7 +39,7 @@ QUnit.test("sets index by the value from a list", function(){
 
 	// Can be set to other stuff too
 	input.value = "none";
-	canEvent.trigger.call(input, "change");
+	domEvents.dispatch.call(input, "change");
 
 	QUnit.equal(map.index, -1, "now -1 because not in the list");
 });

--- a/test/string-to-any_test.js
+++ b/test/string-to-any_test.js
@@ -1,7 +1,7 @@
 require("can-stache-converters");
-var canEvent = require("can-event");
 var DefineList = require("can-define/list/list");
 var DefineMap = require("can-define/map/map");
+var domEvents = require("can-util/dom/events/events");
 var stache = require("can-stache");
 var each = require("can-util/js/each/each");
 
@@ -31,7 +31,7 @@ QUnit.test("Works on all the types", function(){
 	};
 
 	each(types, function(expected, type){
-		var template = stache('<select {($value)}="string-to-any(~val)"><option value="test">test</option><option value="' + type + '">' + type + '</option></select>');
+		var template = stache('<select value:bind="string-to-any(~val)"><option value="test">test</option><option value="' + type + '">' + type + '</option></select>');
 		var map = new DefineMap({
 			val: "test"
 		});
@@ -48,7 +48,7 @@ QUnit.test("Works on all the types", function(){
 
 		// Select this type's option
 		select.value = type;
-		canEvent.trigger.call(select, "change");
+		domEvents.dispatch.call(select, "change");
 
 		QUnit.ok(equality(map.val, expected), "map's value updated to: " + type);
 


### PR DESCRIPTION
This makes can-stache-converters work with 4.0 versions of packages and
uses can-reflect.