### PR TITLE
Export the converters so they can be registered outside of the package

### DIFF
--- a/can-stache-converters.js
+++ b/can-stache-converters.js
@@ -28,108 +28,110 @@ stache.registerConverter("boolean-to-inList", {
 	}
 });
 
-stache.addConverter("string-to-any", {
-	get: function(obs){
-		return "" + canReflect.getValue(obs);
+var converters = {
+	"string-to-any": {
+		get: function(obs){
+			return "" + canReflect.getValue(obs);
+		},
+		set: function(newVal, obs){
+			var converted = stringToAny(newVal);
+			canReflect.setValue(obs, converted);
+		}
 	},
-	set: function(newVal, obs){
-		var converted = stringToAny(newVal);
-		canReflect.setValue(obs, converted);
-	}
-});
-
-stache.addConverter("not", {
-	get: function(obs){
-		return !canReflect.getValue(obs);
+	"not": {
+		get: function(obs){
+			return !canReflect.getValue(obs);
+		},
+		set: function(newVal, obs){
+			canReflect.setValue(obs, !newVal);
+		}
 	},
-	set: function(newVal, obs){
-		canReflect.setValue(obs, !newVal);
-	}
-});
-
-stache.addConverter("index-to-selected", {
-	get: function(item, list){
-		var val = canReflect.getValue(item);
-		var idx = canReflect.getValue(list).indexOf(val);
-		return idx;
+	"index-to-selected": {
+		get: function(item, list){
+			var val = canReflect.getValue(item);
+			var idx = canReflect.getValue(list).indexOf(val);
+			return idx;
+		},
+		set: function(idx, item, list){
+			var newVal = canReflect.getValue(list)[idx];
+			canReflect.setValue(item, newVal);
+		}
 	},
-	set: function(idx, item, list){
-		var newVal = canReflect.getValue(list)[idx];
-		canReflect.setValue(item, newVal);
-	}
-});
-
-stache.addConverter("selected-to-index", {
-	get: function(idx, list){
-		var val = canReflect.getValue(idx),
-			listValue = canReflect.getValue(list);
-		var item = listValue[val];
-		return item;
+	"selected-to-index": {
+		get: function(idx, list){
+			var val = canReflect.getValue(idx),
+				listValue = canReflect.getValue(list);
+			var item = listValue[val];
+			return item;
+		},
+		set: function(item, idx, list){
+			var newVal = canReflect.getValue(list).indexOf(item);
+			canReflect.setValue(idx, newVal);
+		}
 	},
-	set: function(item, idx, list){
-		var newVal = canReflect.getValue(list).indexOf(item);
-		canReflect.setValue(idx, newVal);
-	}
-});
+	"either-or": {
+		get: function(chosen, a, b){
+			var chosenVal = canReflect.getValue(chosen),
+				aValue = canReflect.getValue(a),
+				bValue = canReflect.getValue(b);
+			var matchA = (aValue === chosenVal);
+			var matchB = (bValue === chosenVal);
 
-stache.addConverter("either-or", {
-	get: function(chosen, a, b){
-		var chosenVal = canReflect.getValue(chosen),
-			aValue = canReflect.getValue(a),
-			bValue = canReflect.getValue(b);
-		var matchA = (aValue === chosenVal);
-		var matchB = (bValue === chosenVal);
+			if (!matchA && !matchB) {
+				//!steal-remove-start
+				if (process.env.NODE_ENV !== 'production') {
+					dev.warn(
+						"can-stache-converter.either-or:",
+						"`" + chosenVal + "`",
+						"does not match `" + aValue + "`",
+						"or `" + bValue + "`"
+					);
+				}
+				//!steal-remove-end
 
-		if (!matchA && !matchB) {
-			//!steal-remove-start
-			if (process.env.NODE_ENV !== 'production') {
-				dev.warn(
-					"can-stache-converter.either-or:",
-					"`" + chosenVal + "`",
-					"does not match `" + aValue + "`",
-					"or `" + bValue + "`"
-				);
+				return;
 			}
-			//!steal-remove-end
-
-			return;
-		}
-		else {
-			return matchA;
-		}
-	},
-	set: function(newVal, chosen, a, b){
-		var setVal = newVal ? canReflect.getValue(a) : canReflect.getValue(b);
-		canReflect.setValue(chosen, setVal);
-	}
-});
-
-stache.addConverter("equal", {
-	get: function(){
-		var args = makeArray(arguments);
-		// We don't need the helperOptions
-		args.pop();
-		if (args.length > 1) {
-			var comparer = canReflect.getValue( args.pop() );
-
-			return args.every(function(obs) {
-				var value = canReflect.getValue(obs);
-				return value === comparer;
-			});
+			else {
+				return matchA;
+			}
+		},
+		set: function(newVal, chosen, a, b){
+			var setVal = newVal ? canReflect.getValue(a) : canReflect.getValue(b);
+			canReflect.setValue(chosen, setVal);
 		}
 	},
-	set: function(){
-		var args = makeArray(arguments);
-		// Ignore the helperOptions
-		args.pop();
-		if (args.length > 2) {
-			var b = args.shift();
-			var comparer = args.pop();
-			if(b) {
-				for(var i = 0; i < args.length; i++) {
-					canReflect.setValue(args[i], comparer);
+	"equal": {
+		get: function(){
+			var args = makeArray(arguments);
+			// We don't need the helperOptions
+			args.pop();
+			if (args.length > 1) {
+				var comparer = canReflect.getValue( args.pop() );
+
+				return args.every(function(obs) {
+					var value = canReflect.getValue(obs);
+					return value === comparer;
+				});
+			}
+		},
+		set: function(){
+			var args = makeArray(arguments);
+			// Ignore the helperOptions
+			args.pop();
+			if (args.length > 2) {
+				var b = args.shift();
+				var comparer = args.pop();
+				if(b) {
+					for(var i = 0; i < args.length; i++) {
+						canReflect.setValue(args[i], comparer);
+					}
 				}
 			}
 		}
 	}
-});
+};
+
+// Register itself right away
+stache.addConverter(converters);
+
+module.exports = converters;

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "can-dom-events": "^1.1.1",
     "can-reflect": "^1.11.1",
-    "can-stache": "^4.0.0",
+    "can-stache": "^4.8.0",
     "can-stache-bindings": "^4.0.2",
     "can-util": "^3.10.18"
   },


### PR DESCRIPTION
This makes the package work with tree-shaking. Closes #87