### PR TITLE
remove mentions of tilde for compute

### DIFF
--- a/docs/can-stache-converters.md
+++ b/docs/can-stache-converters.md
@@ -30,7 +30,7 @@ which is after `blur`.
 
 `checked:bind="key"` cross-binds the checked property to a true or false value.
 
-`checked:bind="boolean-to-inList(key, list)"` cross-binds the checked property to `key` being added to / removed from `list`.  The tilde (`~`) is important here because the compute it sets up acts as a channel between the element's property and the scope's property.
+`checked:bind="boolean-to-inList(key, list)"` cross-binds the checked property to `key` being added to / removed from `list`.
 
 `checked:bind="either-or(key, checkedval, uncheckedval)"` cross-binds the checked property to `key`, but uses the `checkedval`
 value to represent checked, and the `uncheckedval` value to represent unchecked.

--- a/docs/equal.md
+++ b/docs/equal.md
@@ -24,7 +24,7 @@ In this example, the `color` scope value will be set to 'red' when the first rad
 
 When the getter is called the two values will be compared and if they are equal, returns true.
 
-In this example there is only a one-way binding, parent to child, so there is no setter case.  This removes the requirement that the first argument is converted to a compute with `~`.
+In this example there is only a one-way binding, parent to child, so there is no setter case.
 
 ```handlebars
 <my-modal show:from="equal(showModal, true)" />


### PR DESCRIPTION
This removes the vestigial documentation referencing the use of "~" operator. 

See https://github.com/canjs/can-stache-converters/issues/76
and 
https://github.com/canjs/can-stache-converters/issues/60